### PR TITLE
chore: Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:latest
+
+RUN mkdir /dosebot
+WORKDIR /dosebot
+
+COPY package*.json ./
+RUN npm ci --only=production
+COPY . .
+
+ENV DISCORD_TOKEN ""
+CMD DISCORD_TOKEN="$DISCORD_TOKEN" node bot.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN mkdir /dosebot
 WORKDIR /dosebot
 
 COPY package*.json ./
-RUN npm install \
- && npx tsc
+RUN npm install
+RUN npx tsc
 COPY . .
 
 ENV DISCORD_TOKEN ""

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 FROM node:latest
 
 RUN mkdir /dosebot
+ADD . /dosebot
 WORKDIR /dosebot
 
-COPY package*.json ./
 RUN npm install
 RUN npx tsc
-COPY . .
 
 ENV DISCORD_TOKEN ""
 CMD DISCORD_TOKEN="$DISCORD_TOKEN" node ./dist/bot.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ RUN mkdir /dosebot
 WORKDIR /dosebot
 
 COPY package*.json ./
-RUN npm ci --only=production
+RUN npm install \
+ && npx tsc \
 COPY . .
 
 ENV DISCORD_TOKEN ""
-CMD DISCORD_TOKEN="$DISCORD_TOKEN" node bot.js
+CMD DISCORD_TOKEN="$DISCORD_TOKEN" node ./dist/bot.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /dosebot
 
 COPY package*.json ./
 RUN npm install \
- && npx tsc \
+ && npx tsc
 COPY . .
 
 ENV DISCORD_TOKEN ""

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,15 @@ This project is maintained by members of the [dosebotredux organization](https:/
 2.  `npm install` to download dependencies
 3.  `DISCORD_API_TOKEN=xxx node bot.js` to start bot
 
+## Docker usage
+
+1.  Clone repo
+2.  Create a `.env` file like so:
+```env
+DISCORD_TOKEN="your token goes here"
+```
+3.  `./start.sh` to build the container and start bot
+
 ## Invite DoseBot Redux to your server!
 
 Want DoseBot Redux on your server? Just click [this link](https://discord.com/oauth2/authorize?client_id=799165497710084116&scope=bot&permissions=268815552) and it shall appear!

--- a/start.sh
+++ b/start.sh
@@ -5,6 +5,8 @@ docker build -t dosebot . || exit $?
 
 source .env || exit $?
 
+docker stop dosebot
+docker rm dosebot
 docker run \
     --name dosebot \
     --network host \

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+git pull
+docker build -t dosebot . || exit $?
+
+source .env || exit $?
+
+docker run \
+    --name dosebot \
+    --network host \
+    -d \
+    --env DISCORD_TOKEN="$DISCORD_TOKEN" \
+    dosebot


### PR DESCRIPTION
This adds a Dockerfile, and the necessary instructions to run it. 

I'm unsure if you want `start.sh` to go in another dir but it is in the repository root for simplicity's sake.