### PR TITLE
fix: Dockerfile start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
+source .env || exit $?
+
 git pull
 docker build -t dosebot . || exit $?
-
-source .env || exit $?
 
 docker stop dosebot
 docker rm dosebot


### PR DESCRIPTION
Let the user (me) know they forgot to set the `.env` before they wait 5 minutes for the build to complete :p