### PR TITLE
fix: `/info` substance parsing

### DIFF
--- a/commands/info.ts
+++ b/commands/info.ts
@@ -181,14 +181,14 @@ function locateCustomSheetLocation(drug_lowercased: string) {
   // Loop through the JSON file and add all of the names and locations to locationsArray
   for (let i = 0; i < customsJSON.data.substances.length; i++) {
     locationsArray.push({
-      name: customsJSON.data.substances[i].name,
+      name: lowerNoSpaceName(customsJSON.data.substances[i].name),
       location: i
     });
   }
 
   // Loop through the locationsArray to find the location of a given substance
   for (let i = 0; i < locationsArray.length; i++) {
-    if (locationsArray[i].name.toLowerCase() == drug_lowercased) {
+    if (locationsArray[i].name.includes(drug_lowercased)) {
       return customsJSON.data.substances[i];
     }
   }
@@ -449,11 +449,12 @@ function buildTSLinksField(substance: TripsafeSubstance) {
 
 // Parses and sanitizes substance name
 function parseSubstanceName(str: string) {
-  const unsanitizedDrugName = str
-    .toLowerCase()
+  // Sanitizes input names to match PsychonautWiki API names
+  return sanitizeSubstanceName(lowerNoSpaceName(str));
+}
+
+function lowerNoSpaceName(str: string) {
+    return str.toLowerCase()
     .replace(/^[^\s]+ /, '') // remove first word
     .replace(/ /g, '');
-
-  // Sanitizes input names to match PsychonautWiki API names
-  return sanitizeSubstanceName(unsanitizedDrugName);
 }


### PR DESCRIPTION
Currently, the `locateSubstanceSheet` function indexes substances using their `Proper Name`. but uses the `parsedname` when searching it, so it isn't really ever used for drugs that contain a space in their name (such as Psilocybin mushrooms).

This changes it to index by the `parsedname` as well as use `.includes(drug_lowercased)` rather than match whole, because users might not type out the full name.

Please let me know if you'd like this accomplished differently, I'm not sure if you'd rather use `sanitize-substance-name` (and add aliases for mushrooms / shrooms) to accomplish this.
  
![image](https://user-images.githubusercontent.com/17222512/203927461-af41c83c-a3b6-4fe7-86d5-02ca44e72d03.png)
